### PR TITLE
 #22 :construction: work: テーブル追加

### DIFF
--- a/db/migrate/20231221090630_create_users.rb
+++ b/db/migrate/20231221090630_create_users.rb
@@ -1,0 +1,14 @@
+class CreateUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :users do |t|
+      t.string :name, null: false
+      t.string :email, null: false, index: { unique: true }
+      t.string :crypted_password
+      t.integer :role, default: 0
+      t.integer :public_status, default: 0
+      t.string :salt
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231221093633_create_prefectures.rb
+++ b/db/migrate/20231221093633_create_prefectures.rb
@@ -1,0 +1,9 @@
+class CreatePrefectures < ActiveRecord::Migration[7.1]
+  def change
+    create_table :prefectures do |t|
+      t.string :name, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231221093750_create_areas.rb
+++ b/db/migrate/20231221093750_create_areas.rb
@@ -1,0 +1,9 @@
+class CreateAreas < ActiveRecord::Migration[7.1]
+  def change
+    create_table :areas do |t|
+      t.string :name, null: false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231221093912_create_cities.rb
+++ b/db/migrate/20231221093912_create_cities.rb
@@ -1,0 +1,13 @@
+class CreateCities < ActiveRecord::Migration[7.1]
+  def change
+    create_table :cities do |t|
+      t.references :prefecture, foreign_key: true
+      t.string :address
+      t.float :latitude
+      t.float :longitude
+      t.references :area, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231221094508_create_posts.rb
+++ b/db/migrate/20231221094508_create_posts.rb
@@ -1,0 +1,14 @@
+class CreatePosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :posts do |t|
+      t.references :user, foreign_key: true
+      t.string :location, null:false
+      t.references :prefecture, foreign_key: true
+      t.string :text, null: false
+      t.integer :event_status, default: 0
+      t.integer :public_status, default: 0
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231221122613_create_tags.rb
+++ b/db/migrate/20231221122613_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null:false, index: { unique: true }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231221122730_create_post_tags.rb
+++ b/db/migrate/20231221122730_create_post_tags.rb
@@ -1,0 +1,10 @@
+class CreatePostTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, foreign_key: true
+      t.references :tag, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231221123522_create_bookmarks.rb
+++ b/db/migrate/20231221123522_create_bookmarks.rb
@@ -1,0 +1,10 @@
+class CreateBookmarks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :bookmarks do |t|
+      t.references :user, foreign_key: true
+      t.references :post, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,92 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 0) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_21_123522) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
+
+  create_table "areas", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_areas_on_name", unique: true
+  end
+
+  create_table "bookmarks", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_bookmarks_on_post_id"
+    t.index ["user_id"], name: "index_bookmarks_on_user_id"
+  end
+
+  create_table "cities", force: :cascade do |t|
+    t.bigint "prefecture_id"
+    t.string "address"
+    t.float "latitude"
+    t.float "longitude"
+    t.bigint "area_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["area_id"], name: "index_cities_on_area_id"
+    t.index ["prefecture_id"], name: "index_cities_on_prefecture_id"
+  end
+
+  create_table "post_tags", force: :cascade do |t|
+    t.bigint "post_id"
+    t.bigint "tag_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "location", null: false
+    t.bigint "prefecture_id"
+    t.string "text", null: false
+    t.integer "event_status", default: 0
+    t.integer "public_status", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["prefecture_id"], name: "index_posts_on_prefecture_id"
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "prefectures", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_prefectures_on_name", unique: true
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", null: false
+    t.string "crypted_password"
+    t.integer "role", default: 0
+    t.integer "public_status", default: 0
+    t.string "salt"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "bookmarks", "posts"
+  add_foreign_key "bookmarks", "users"
+  add_foreign_key "cities", "areas"
+  add_foreign_key "cities", "prefectures"
+  add_foreign_key "post_tags", "posts"
+  add_foreign_key "post_tags", "tags"
+  add_foreign_key "posts", "prefectures"
+  add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
# 概要
- 各種テーブルの追加

# 内容
## Users ユーザー登録
- name ユーザー名
- email メールアドレス
- Crypted_password パスワード（sorcery）
- role 権限（enumでadmin、general振り分け）
- public_status（enumでpublic、privateを振り分け）
- salt（sorcery）

## Posts 観光地投稿
- user_id 外部キー
- location 観光地名（例：スカイツリー、鎌倉大仏、湘南の海等）
- prefecture_id
- text 本文（旅行の思い出などを記載）
- event_status イベントの開催状況（補足：（enum { permanent: 0, seasonal: 1 }等にして常設か期間限定かを管理）
- public_status 公開可否（enumで公開・非公開を管理）

## PostTags 中間テーブル
- post_id
 - tag_id

## Tags タグ
- name タグの名前

## Bookmarks ブックマーク（行きたい場所リスト）
- user_id
- post_id

## prefectures 都道府県
- name 都道府県名
- cities 住所（市区町村以降）
- prefecture_id
- address 住所（Geocoding APIで取得した住所を保存）
- latitude 緯度（Geocoding API）　
- longitude 経度（Geocoding API）
- area_id

## Areas エリア区分（補足：各都道府県を4分割した際のエリア分け。例：茨城→県央・県南・県北・県西に分けた場合のCitiesを管理するために使用）
- name エリア名（茨城県央、神奈川横浜。東京２３区内等）　※詳細検索に用います。

# ER図
[![Image from Gyazo](https://i.gyazo.com/cb58467f61dcb0d06daebcf83c63d76a.png)](https://gyazo.com/cb58467f61dcb0d06daebcf83c63d76a)