### PR TITLE
Feature/post index view

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   private
 
   def not_authenticated
-    flash.now[:alert] = t('defaults.require_login')
+    flash[:alert] = t('defaults.require_login')
     redirect_to login_path
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
 
   # GET /posts or /posts.json
   def index
-    @posts = Post.all
+    @posts = Post.includes(:user, :prefecture).all
   end
 
   # GET /posts/1 or /posts/1.json

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,2 +1,11 @@
-<div id="<%= dom_id post %>">
+<div id="post-id-<%= post.id %>">
+  <a href="#" class="group relative flex h-48 items-end overflow-hidden rounded-lg bg-gray-100 shadow-lg md:h-80">
+    <img src="#" loading="lazy" alt="sample" class="absolute inset-0 h-full w-full object-cover object-center transition duration-200 group-hover:scale-110" />
+
+    <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50"></div>
+
+    <span class="relative ml-4 mb-3 inline-block text-sm text-white md:ml-5 md:text-lg"><%= post.prefecture.name %></span>
+    <span class="relative ml-4 mb-3 inline-block text-sm text-white md:ml-5 md:text-lg"><%= post.location %></span>
+  </a>
+  <span><%= post.user.name %></span>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,14 +1,95 @@
-<p style="color: green"><%= notice %></p>
+<section class="text-gray-600 body-font">
+  <div class="container px-5 py-24 mx-auto">
+    <div class="flex flex-col">
+      <div class="h-1 bg-gray-200 rounded overflow-hidden">
+        <div class="w-24 h-full bg-pink-500"></div>
+      </div>
+      <div class="flex flex-wrap sm:flex-row flex-col py-6 mb-12">
+        <h1 class="sm:w-2/5 text-gray-900 font-medium title-font text-2xl mb-2 sm:mb-0">レコメンドの提供</h1>
+        <p class="sm:w-3/5 leading-relaxed text-base sm:pl-10 pl-0">ログイン後機能、MVP後の機能</p>
+      </div>
+    </div>
+    <div class="flex flex-wrap sm:-m-4 -mx-4 -mb-10 -mt-4">
+      <div class="p-4 md:w-1/3 sm:mb-0 mb-6">
+        <div class="rounded-lg h-64 overflow-hidden">
+          <img alt="content" class="object-cover object-center h-full w-full" src="https://dummyimage.com/1203x503">
+        </div>
+        <a class="text-pink-500 inline-flex items-center mt-3">Learn More
+          <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
+            <path d="M5 12h14M12 5l7 7-7 7"></path>
+          </svg>
+        </a>
+      </div>
+      <div class="p-4 md:w-1/3 sm:mb-0 mb-6">
+        <div class="rounded-lg h-64 overflow-hidden">
+          <img alt="content" class="object-cover object-center h-full w-full" src="https://dummyimage.com/1204x504">
+        </div>
+        <a class="text-pink-500 inline-flex items-center mt-3">Learn More
+          <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
+            <path d="M5 12h14M12 5l7 7-7 7"></path>
+          </svg>
+        </a>
+      </div>
+      <div class="p-4 md:w-1/3 sm:mb-0 mb-6">
+        <div class="rounded-lg h-64 overflow-hidden">
+          <img alt="content" class="object-cover object-center h-full w-full" src="https://dummyimage.com/1205x505">
+        </div>
+        <a class="text-pink-500 inline-flex items-center mt-3">Learn More
+          <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
+            <path d="M5 12h14M12 5l7 7-7 7"></path>
+          </svg>
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
 
-<h1>Posts</h1>
+<section class="text-gray-600 body-font">
+  <div class="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
+    <div class="lg:max-w-lg lg:w-full md:w-1/2 w-5/6 mb-10 md:mb-0">
+      <img class="object-cover object-center rounded" alt="hero" src="https://dummyimage.com/720x600">
+    </div>
+    <div class="lg:flex-grow md:w-1/2 lg:pl-24 md:pl-16 flex flex-col md:items-start md:text-left items-center text-center">
+      <h1 class="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900">条件検索
+      </h1>
+      <h4>都道府県</h4>
+      <select class="select select-bordered select-sm w-full max-w-xs">
+        <option disabled selected>全て選択</option>
+        <option>Small Apple</option>
+        <option>Small Orange</option>
+        <option>Small Tomato</option>
+      </select>
+      <h4>エリア</h4>
+      <select class="select select-bordered select-sm w-full max-w-xs">
+        <option disabled selected>全て選択</option>
+        <option>Small Apple</option>
+        <option>Small Orange</option>
+        <option>Small Tomato</option>
+      </select>
+      <h4>キーワード</h4>
+      <input type="text" placeholder="フリーワード" class="input input-bordered input-sm w-full max-w-xs" />
+      <h4>タグ</h4>
+      <input type="text" placeholder="フリーワード" class="input input-bordered input-sm w-full max-w-xs" />
+      <h4>検索オプション</h4>
+      <input type="checkbox" checked="checked" class="checkbox checkbox-sm" /> 未踏破の都道府県に絞り込む
+      <input type="checkbox" checked="checked" class="checkbox checkbox-sm" /> 期間限定の観光地・イベントを除外する
+      <div class="flex justify-center">
+        <button class="inline-flex text-white bg-pink-500 border-0 py-2 px-6 focus:outline-none hover:bg-pink-600 rounded text-lg">検索</button>
+      </div>
+    </div>
+  </div>
+</section>
 
-<div id="posts">
-  <% @posts.each do |post| %>
-    <%= render post %>
-    <p>
-      <%= link_to "Show this post", post %>
-    </p>
-  <% end %>
+<div class="bg-white py-6 sm:py-8 lg:py-12">
+  <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
+    <h2 class="mb-4 text-center text-2xl font-bold text-gray-800 md:mb-8 lg:text-3xl xl:mb-12">投稿一覧</h2>
+
+    <div class="mb-4 grid grid-cols-2 gap-4 sm:grid-cols-3 md:mb-8 md:grid-cols-4 md:gap-6 xl:gap-8">
+        <% if @posts.present? %>
+          <%= render @posts %>
+        <% else %>
+          <div class="mb-3">投稿がありません</div>
+        <% end %>
+    </div>
+  </div>
 </div>
-
-<%= link_to "New post", new_post_path %>


### PR DESCRIPTION
## 概要
- 検索ページとなる「探す」ページ作成
- 投稿を表示するパーシャルの作成

## 内容
- `get '/search', to: 'posts#index', as: 'search'`に設定
- `posts/_pots.html.erb`を作成
  - `posts/index.html.erb`で上記パーシャルを読み込み、投稿件数に応じて表示