### PR TITLE
 :adhesive_bandage: fix: 「,」記入漏れによるビルドエラー修正

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,7 +6,7 @@ CarrierWave.configure do |config|
     provider:              'AWS',
     aws_access_key_id:     ENV['AWS_ACCESS_KEY_ID'],
     aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-    region:                ENV['AWS_DEFAULT_REGION']
+    region:                ENV['AWS_DEFAULT_REGION'],
     path_style: true
   }
 end


### PR DESCRIPTION
## 概要
- ビルドエラー対応

## 内容
```
-----> Preparing app for Rails asset pipeline
       Running: rake assets:precompile
       rake aborted!
       SyntaxError: --> /tmp/build_4857094e/config/initializers/carrierwave.rb
       syntax error, unexpected ':', expecting end-of-input
          1  CarrierWave.configure do |config|
          5    config.fog_credentials = {
       >  6      provider:              'AWS',
       >  7      aws_access_key_id:     ENV['AWS_ACCESS_KEY_ID'],
       >  8      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
       >  9      region:                ENV['AWS_DEFAULT_REGION']
       > 10      path_style: true
         11    }
         12  end
```