### PR TITLE
 fix: require 'debug'の記述が残ってしまっていたことによるアプリクラッシュの改善

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,3 @@
-require 'debug'
-
 class PostsController < ApplicationController
   before_action :set_post, only: %i[show edit update destroy]
   skip_before_action :require_login, only: %i[index show]


### PR DESCRIPTION
## 概要
```
/app/vendor/bundle/ruby/3.2.0/gems/bootsnap-1.17.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:29:in `require': cannot load such file -- debug (LoadError)
```
