### PR TITLE
 :art: style: 日本地図をパーシャルに切り分け、全体レイアウト調整

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,6 +4,7 @@ class PostsController < ApplicationController
 
   # /search
   def index
+    @user_prefectures = UserPrefecture.all
     @posts = if (tag_name = params[:tag_name])
                # タグ名に基づいて投稿を取得し、関連するユーザー、都道府県、タグを事前読み込み
                Post.with_tag(tag_name).includes(:user, :prefecture, :tags).order(created_at: :desc)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,9 @@
 class UsersController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
   def index
+    @posts = current_user.posts.includes(:prefecture, :tags).order(created_at: :desc)
     @user_prefectures = UserPrefecture.where(user_id: current_user.id)
+    @context = 'posts'
   end
 
   def new

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,23 +1,24 @@
 <%= form_with model: post, local: true, class: "space-y-4" do |f| %>
   <%= render 'shared/error_messages', model: f.object %>
+  <div class="flex flex-col gap-4 p-4 md:p-8">
 
   <!-- 都道府県のプルダウンメニュー -->
   <div>
-    <%= f.label :prefecture_id, class: "block text-sm font-medium text-gray-700" %>
-    <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt: "選択必須"}, {class: "select select-bordered select-sm w-full max-w-xs"} %>
+    <%= f.label :prefecture_id, class: "block mb-2 text-sm text-gray-800 sm:text-base" %>
+    <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {prompt: "選択必須"}, {class: "block select select-bordered select-sm w-full max-w-xs"} %>
   </div>
 
   <!-- 観光地名のテキストフィールド -->
   <div>
-    <%= f.label :location, class: "block text-sm font-medium text-gray-700" %>
-    <%= f.text_field :location, placeholder: "観光地名やスポット名を記入してください", class: "input input-bordered input-sm w-full max-w-xs" %>
+    <%= f.label :location, class: "block mb-2 inline-block text-sm text-gray-800 sm:text-base" %>
+    <%= f.text_field :location, placeholder: "観光地名やスポット名を記入してください", class: "block input input-bordered input-sm w-full max-w-xs" %>
   </div>
 
 
   <!-- 画像選択 -->
   <div>
     <%= f.label :images, "画像を選択（最低1枚、最大4枚）", class: "block text-sm font-medium text-gray-700" %>
-    <%= f.file_field :images, multiple: true, class: "file-input file-input-bordered w-full max-w-xs", accept: 'image/jpeg,image/png,image/webp,image/heic' %>
+    <%= f.file_field :images, multiple: true, class: "block file-input file-input-bordered w-full max-w-xs", accept: 'image/jpeg,image/png,image/webp,image/heic' %>
     <!-- <%= f.hidden_field :images_cache %> -->
     <% post.images.each do |image| %>
       <%= hidden_field :post, :images, multiple: true, value: image.identifier %>
@@ -27,34 +28,34 @@
   <% if @post.images? %>
     <div class="flex flex-row space-x-4">
     <% @post.images.each do |image| %>
-      <%= image_tag(image.url(), class: "h-15 w-20") %>
-      <%= link_to '削除', '#', method: :delete, data: { confirm: '本当に削除しますか？' }, class: "text-xs text-red-600" %> <!-- 削除リンク -->
+      <%= image_tag(image.url(), class: "block h-15 w-20") %>
+      <%= link_to '削除', '#', method: :delete, data: { confirm: '本当に削除しますか？' }, class: "block text-xs text-red-600" %> <!-- 削除リンク -->
     <% end %>
     </div>
   <% end %>
 
   <!-- 旅行の思い出 -->
   <div>
-    <%= f.label :text, class: "block text-sm font-medium text-gray-700" %>
-    <%= f.text_area :text, rows: 3, placeholder: "旅の思い出やオススメポイントを自由に記入してください", class: "textarea textarea-bordered textarea-sm w-full max-w-xs" %>
+    <%= f.label :text, class: "block mb-2 inline-block text-sm text-gray-800 sm:text-base" %>
+    <%= f.text_area :text, rows: 3, placeholder: "旅の思い出やオススメポイントを自由に記入してください", class: "block textarea textarea-bordered textarea-sm w-full max-w-xs" %>
   </div>
 
   <!-- 観光地の開催時期と公開設定 -->
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <div>
-      <%= f.label :event_status, class: "block text-sm font-medium text-gray-700" %>
+      <%= f.label :event_status, class: "mb-2 block text-sm font-medium text-gray-700" %>
       <div class="mt-1 flex items-center">
-        <%= f.radio_button :event_status, 'permanent', class: "radio", id: "event_status_permanent", checked: true %>
-        <%= f.label :event_status_permanent, '通年', class: "ml-2 block text-sm font-medium text-gray-700" %>
-        <%= f.radio_button :event_status, 'seasonal', class: "radio", id: "event_status_seasonal" %>
+        <%= f.radio_button :event_status, 'permanent', class: "radio", id: "block event_status_permanent", checked: true %>
+        <%= f.label :event_status_permanent, '通年', class: "mr-4 ml-2 block text-sm font-medium text-gray-700" %>
+        <%= f.radio_button :event_status, 'seasonal', class: "block radio", id: "event_status_seasonal" %>
         <%= f.label :event_status_seasonal, '期間限定', class: "ml-2 block text-sm font-medium text-gray-700" %>
       </div>
 
       <fieldset>
-        <%= f.label :public_status, class: "block text-sm font-medium text-gray-700" %>
+        <%= f.label :public_status, class: "mt-2 mb-2 block text-sm font-medium text-gray-700" %>
         <div class="mt-1 flex items-center">
           <%= f.radio_button :public_status, 'open', id: 'public_status_open', class: "radio", checked: true %>
-          <%= f.label :public_status_open, '公開', class: "ml-2 block text-sm font-medium text-gray-700" %>
+          <%= f.label :public_status_open, '公開', class: "mr-4 ml-2 block text-sm font-medium text-gray-700" %>
           <%= f.radio_button :public_status, 'closed', id: 'public_status_close', class: "radio" %>
           <%= f.label :public_status_close, '非公開', class: "ml-2 block text-sm font-medium text-gray-700" %>
         </div>
@@ -64,12 +65,13 @@
 
   <!-- タグ（将来的に実装） -->
   <div>
-    <%= f.label :tag_names, "タグ", class: "block text-sm font-medium text-gray-700" %>
-    <%= f.text_field :tag_names, value: @post.tags.pluck(:name).join(", "), placeholder: ",で区切って5個まで入力できます", class: "input input-bordered input-sm w-full max-w-xs" %>
+    <%= f.label :tag_names, "タグ", class: "block mb-2 inline-block text-sm text-gray-800 sm:text-base" %>
+    <%= f.text_field :tag_names, value: @post.tags.pluck(:name).join(", "), placeholder: ",で区切って5個まで入力できます", class: "block input input-bordered input-sm w-full max-w-xs" %>
   </div>
 
   <!-- 送信ボタン -->
   <div>
-    <%= f.submit "投稿する", class: "inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+    <%= f.submit "投稿する", class: "w-full inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500" %>
+  </div>
   </div>
 <% end %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -24,8 +24,8 @@
 
   <!-- bookmarks -->
   <% if current_user.bookmark?(post) %>
-    <%= render 'unbookmark', post: post %>
+    <%= render 'posts/unbookmark', post: post %>
   <% else %>
-    <%= render 'bookmark', post: post %>
+    <%= render 'posts/bookmark', post: post %>
   <% end %>
 </div>

--- a/app/views/posts/bookmarks.html.erb
+++ b/app/views/posts/bookmarks.html.erb
@@ -7,6 +7,12 @@
       <turbo-frame id="bookmarks_frame" style="display: none;">
         <%= render partial: "posts/bookmarks_frame", locals: { bookmark_posts: @bookmark_posts, context: @context } %>
       </turbo-frame>
+      <!-- posts#bookmarksが直接参照された時に表示 -->
+        <% if @bookmark_posts.present? %>
+          <%= render partial: "post", collection: @bookmark_posts, as: :post, locals: { context: @context } %>
+        <% else %>
+          <div class="mb-3">ブックマーク中の投稿がありません</div>
+        <% end %>
     </div>
   </div>
 </div>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,7 +1,7 @@
-<div class='container flex justify-center'>
-  <div class='row'>
-    <div class='col-md-10 col-lg-8 mx-auto'>
-      <h1>投稿編集</h1>
+<div class='container mx-auto px-4'>
+  <div class='flex justify-center'>
+    <div class='w-full max-w-lg'>
+      <h2 class="mb-4 mt-6 text-center text-2xl font-bold text-gray-800 md:mb-8 lg:text-3xl">投稿編集</h2>
       <%= render 'form', post: @post %>
     </div>
   </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,3 +1,4 @@
+<!-- レコメンド
 <section class="text-gray-600 body-font">
   <div class="container px-5 py-24 mx-auto">
     <div class="flex flex-col">
@@ -23,13 +24,14 @@
     </div>
   </div>
 </section>
+-->
 
 <section class="text-gray-600 body-font">
   <div class="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center">
     <div class="lg:max-w-lg lg:w-full md:w-1/2 w-5/6 mb-10 md:mb-0">
-          <h1 class="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900">条件検索
-      </h1>
-      <img class="object-cover object-center rounded" alt="hero" src="https://dummyimage.com/720x600">
+      <!-- 色塗りマップ -->
+      <h1 class="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900">条件検索</h1>
+      <%= render 'users/japanmap', user_prefectures: @user_prefectures %>
     </div>
     <div class="lg:flex-grow md:w-1/2 lg:pl-24 md:pl-16 flex flex-col md:items-start md:text-left items-center text-center">
       <h4>都道府県</h4>
@@ -62,9 +64,6 @@
 
 <div id="posts-list-section" class="bg-white py-6 sm:py-8 lg:py-12">
   <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
-  
-
-
       <div>
         <p>
           <label class="label cursor-pointer justify-end">
@@ -74,15 +73,12 @@
         </label>
         </p>
       </div>
-
       <turbo-frame id="posts_frame">
         <%= render partial: "posts/posts_frame" %>
       </turbo-frame>
-
       <turbo-frame id="bookmarks_frame" src="/posts/bookmarks" style="display: none;">
         <%= render partial: "posts/bookmarks_frame", locals: { bookmark_posts: @bookmark_posts, context: @context } %>
       </turbo-frame>
-
   </div>
 </div>
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,7 +1,7 @@
-<div class='container flex justify-center'>
-  <div class='row'>
-    <div class='col-md-10 col-lg-8 mx-auto'>
-      <h1>新規投稿</h1>
+<div class='container mx-auto px-4'>
+  <div class='flex justify-center'>
+    <div class='w-3/4 max-w-lg'>
+      <h2 class="mb-4 mt-6 text-center text-2xl font-bold text-gray-800 md:mb-8 lg:text-3xl">新規登録</h2>
       <%= render 'form', post: @post %>
     </div>
   </div>

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -1,12 +1,12 @@
 <section class="text-gray-600 body-font">
   <div class="container mx-auto flex px-5 py-24 items-center justify-center flex-col">
-    <h1 class="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900">タイトル</h1>
+    <h1 class="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900">Travel_app</h1>
     <%= image_tag 'nihonchizu.png', class: 'w-[720px] h-[600px]' %>
     <div class="text-center lg:w-2/3 w-full">
-      <p class="mb-8 leading-relaxed">🐟🐟🐟🐟🐟🐟🐟🐟🐟🐟🐟🐟</p>
+      <p class="mb-8 leading-relaxed">うんたらかんたら</p>
       <div class="flex justify-center">
-        <button class="inline-flex text-white bg-red-500 border-0 py-2 px-6 focus:outline-none hover:bg-red-600 rounded text-lg">Button</button>
-        <button class="ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg">Button</button>
+        <button class="inline-flex text-white bg-red-500 border-0 py-2 px-6 focus:outline-none hover:bg-red-600 rounded text-lg">サンプル削除</button>
+        <button class="ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg">サンプル登録</button>
       </div>
     </div>
   </div>
@@ -15,13 +15,14 @@
 <section class="text-gray-600 body-font">
   <div class="container px-5 py-24 mx-auto">
     <div class="text-center mb-20">
-      <h1 class="sm:text-3xl text-2xl font-medium title-font text-gray-900 mb-4">使ってみる</h1>
-      <p class="text-base leading-relaxed xl:w-2/4 lg:w-3/4 mx-auto text-gray-500s">🐟🐟🐟🐟🐟🐟🐟🐟🐟🐟🐟🐟</p>
+      <h1 class="sm:text-3xl text-2xl font-medium title-font text-gray-900 mb-4">How to use</h1>
+      <p class="text-base leading-relaxed xl:w-2/4 lg:w-3/4 mx-auto text-gray-500s">使ってみよう！</p>
       <div class="flex mt-6 justify-center">
         <div class="w-16 h-1 rounded-full bg-red-500 inline-flex"></div>
       </div>
     </div>
-    <div class="flex flex-wrap justify-center items-center sm:-m-4 -mx-4 -mb-10 -mt-4 md:space-y-0 space-y-6">
+
+    <div class="flex flex-col md:flex-row justify-center items-center sm:-m-4 -mx-4 -mb-10 -mt-4 md:space-y-0 space-y-6">
       <div class="p-4 md:w-1/3 flex flex-col text-center items-center">
         <div class="w-20 h-20 inline-flex items-center justify-center rounded-full bg-red-100 text-red-500 mb-5 flex-shrink-0">
           <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10" viewBox="0 0 24 24">
@@ -39,6 +40,7 @@
           <% end %>
         </div>
       </div>
+
       <div class="p-4 md:w-1/3 flex flex-col text-center items-center">
         <div class="w-20 h-20 inline-flex items-center justify-center rounded-full bg-red-100 text-red-500 mb-5 flex-shrink-0">
           <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-10 h-10" viewBox="0 0 24 24">

--- a/app/views/users/_japanmap.html.erb
+++ b/app/views/users/_japanmap.html.erb
@@ -1,0 +1,42 @@
+<% prefectures = [
+  "hokkaido",
+  "aomori", "iwate", "miyagi", "akita",
+  "yamagata", "fukushima", "ibaraki", "tochigi",
+  "gunma", "saitama", "chiba", "tokyo", "kanagawa",
+  "niigata", "toyama", "ishikawa", "fukui", "yamanashi",
+  "nagano", "gifu", "shizuoka", "aichi", "mie",
+  "shiga", "kyoto", "osaka", "hyogo", "nara",
+  "wakayama", "tottori", "shimane", "okayama", "hiroshima",
+  "yamaguchi", "tokushima", "kagawa", "ehime", "kochi",
+  "fukuoka", "saga", "nagasaki", "kumamoto", "oita",
+  "miyazaki", "kagoshima", "okinawa"
+] %>
+
+<% svg_path = Rails.root.join('app', 'assets', 'images', 'japan.svg') %>
+<% svg_data = File.read(svg_path) %>
+<% prefectures.each_with_index do |prefecture, index| %>
+  <% prefecture_id = index + 1 %>
+  <% user_prefecture = user_prefectures.find { |up| up.prefecture_id == prefecture_id } %>
+  
+  <%# biwaが含まれている場合は.bg-biwaクラスを適用する %>
+  <% if prefecture.include?('biwa') %>
+    <% count_class = 'bg-biwa' %>
+  <% else %>
+    <% count_class = user_prefecture && user_prefecture.post_count >= 4 ? "bg-count-4" : "bg-count-#{user_prefecture ? user_prefecture.post_count : 0}" %>
+  <% end %>
+
+  <% svg_data.gsub!(/<path id="#{prefecture}"( class="[^"]*")?/, '<path id="' + prefecture + '" class="' + count_class + '"') %>
+<% end %>
+<%= raw(svg_data).html_safe %>
+
+<!-- パターンB 滋賀塗りつぶし =begin
+<% svg_path = Rails.root.join('app', 'assets', 'images', 'japan.svg') %>
+<% svg_data = File.read(svg_path) %>
+<% prefectures.each_with_index do |prefecture, index| %>
+  <% prefecture_id = index + 1 %>
+  <% user_prefecture = @user_prefectures.find { |up| up.prefecture_id == prefecture_id } %>
+  <% count_class = user_prefecture && user_prefecture.post_count >= 4 ? "bg-count-4" : "bg-count-#{user_prefecture ? user_prefecture.post_count : 0}" %>
+  <% svg_data.gsub!(/<path id="#{prefecture}"( class="[^"]*")?/, '<path id="' + prefecture + '" class="' + count_class + '"') %>
+<% end %>
+<%= raw(svg_data).html_safe %>
+=end -->

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,75 +1,18 @@
 <section class="text-gray-600 body-font">
   <div class="container mx-auto flex px-5 py-24 items-center justify-center flex-col">
     <h1 class="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900">マイページ</h1>
-
-    <% prefectures = [
-      "hokkaido",
-      "aomori", "iwate", "miyagi", "akita",
-      "yamagata", "fukushima", "ibaraki", "tochigi",
-      "gunma", "saitama", "chiba", "tokyo", "kanagawa",
-      "niigata", "toyama", "ishikawa", "fukui", "yamanashi",
-      "nagano", "gifu", "shizuoka", "aichi", "mie",
-      "shiga", "kyoto", "osaka", "hyogo", "nara",
-      "wakayama", "tottori", "shimane", "okayama", "hiroshima",
-      "yamaguchi", "tokushima", "kagawa", "ehime", "kochi",
-      "fukuoka", "saga", "nagasaki", "kumamoto", "oita",
-      "miyazaki", "kagoshima", "okinawa"
-    ] %>
-
-
-
-<% svg_path = Rails.root.join('app', 'assets', 'images', 'japan.svg') %>
-<% svg_data = File.read(svg_path) %>
-<% prefectures.each_with_index do |prefecture, index| %>
-  <% prefecture_id = index + 1 %>
-  <% user_prefecture = @user_prefectures.find { |up| up.prefecture_id == prefecture_id } %>
-  
-  <%# biwaが含まれている場合は.bg-biwaクラスを適用する %>
-  <% if prefecture.include?('biwa') %>
-    <% count_class = 'bg-biwa' %>
-  <% else %>
-    <% count_class = user_prefecture && user_prefecture.post_count >= 4 ? "bg-count-4" : "bg-count-#{user_prefecture ? user_prefecture.post_count : 0}" %>
-  <% end %>
-
-  <% svg_data.gsub!(/<path id="#{prefecture}"( class="[^"]*")?/, '<path id="' + prefecture + '" class="' + count_class + '"') %>
-<% end %>
-<%= raw(svg_data).html_safe %>
-
-<!-- パターンB 滋賀塗りつぶし =begin
-<% svg_path = Rails.root.join('app', 'assets', 'images', 'japan.svg') %>
-<% svg_data = File.read(svg_path) %>
-<% prefectures.each_with_index do |prefecture, index| %>
-  <% prefecture_id = index + 1 %>
-  <% user_prefecture = @user_prefectures.find { |up| up.prefecture_id == prefecture_id } %>
-  <% count_class = user_prefecture && user_prefecture.post_count >= 4 ? "bg-count-4" : "bg-count-#{user_prefecture ? user_prefecture.post_count : 0}" %>
-  <% svg_data.gsub!(/<path id="#{prefecture}"( class="[^"]*")?/, '<path id="' + prefecture + '" class="' + count_class + '"') %>
-<% end %>
-<%= raw(svg_data).html_safe %>
-=end -->
-
-
-
-
-
+    <!-- 色塗りマップ -->
+    <%= render 'japanmap', user_prefectures: @user_prefectures %>
 
   </div>
 </section>
 
 <div class="container mx-auto px-4">
-  <div class="container mx-auto flex px-5 py-24 items-center justify-center flex-col">
-    <div class="text-center lg:w-2/3 w-full">
-      <p class="mb-8 leading-relaxed">現在の踏破状況</p>
-      <div class="flex justify-center">
-        <button class="inline-flex text-white bg-red-500 border-0 py-2 px-6 focus:outline-none hover:bg-red-600 rounded text-lg">削除</button>
-        <button class="ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg">登録</button>
-      </div>
-    </div>
-  </div>
-  <div class="grid grid-cols-2 gap-4 mx-auto max-w-lg rounded-lg"> <!-- mx-auto max-w-lg rounded-lg border -->
-    <button class="btn btn-primary col-span-2 sm:col-span-1 max-w-xs">投稿する</button>
-    <button class="btn btn-secondary col-span-2 sm:col-span-1 max-w-xs">他の人の投稿を見る</button>
-    <button class="btn btn-accent col-span-2 sm:col-span-1 max-w-xs">ランキング</button>
-    <%= link_to 'ブックマーク', bookmarks_posts_path, class: 'btn btn-ghost col-span-2 sm:col-span-1 max-w-xs', role: "button" %>
+  <div id="buttons" class="grid grid-cols-2 gap-4 mx-auto max-w-lg rounded-lg"> <!-- mx-auto max-w-lg rounded-lg border -->
+    <%= link_to '投稿する', new_post_path, class: "btn btn-primary col-span-2 sm:col-span-1 max-w-xs" %>
+    <%= link_to '他の人の投稿を見る', '/search', class: "btn btn-secondary col-span-2 sm:col-span-1 max-w-xs" %>
+    <%= link_to '準備中', '#buttons', class: "btn disabled" %> 
+    <%= link_to 'ブックマーク', bookmarks_posts_path, class: 'btn btn-accent col-span-2 sm:col-span-1 max-w-xs', role: "button" %>
   </div>
 </div>
 
@@ -85,71 +28,17 @@
 = end -->
 
 
-<section class="text-gray-600 body-font">
-  <div class="container px-5 py-24 mx-auto">
-    <div class="flex flex-col">
-      <div class="h-1 bg-gray-200 rounded overflow-hidden">
-        <div class="w-24 h-full "></div>
+<div id="posts-list-section" class="bg-white py-6 sm:py-8 lg:py-12">
+  <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
+  <h2 class="mb-4 text-center text-2xl font-bold text-gray-800 md:mb-8 lg:text-3xl xl:mb-12"><%= current_user.name %>さんの投稿一覧</h2>
+  <div class="mb-4 grid grid-cols-2 gap-4 sm:grid-cols-3 md:mb-8 md:grid-cols-4 md:gap-6 xl:gap-8">
+    <% if @posts.present? %>
+      <%= render partial: 'posts/post', collection: @posts, as: :post %>
+    <% else %>
+      <div class="flex flex-col items-center justify-center h-screen">
+        <div class="text-xl font-bold mb-4">まだ投稿していません！</div>
+        <%= link_to '投稿する', new_post_path, class: "btn btn-primary px-4 py-2 rounded bg-blue-500 hover:bg-blue-700 text-white font-bold" %>
       </div>
-      <div class="flex flex-wrap sm:flex-row flex-col py-6 mb-12">
-        <h1 class="sm:w-2/5 text-gray-900 font-medium title-font text-2xl mb-2 sm:mb-0">さばの投稿一覧</h1>
-        <p class="sm:w-3/5 leading-relaxed text-base sm:pl-10 pl-0">Street art subway tile salvia four dollar toast bitters selfies quinoa yuccie synth meditation iPhone intelligentsia prism tofu. Viral gochujang bitters dreamcatcher.</p>
-      </div>
-    </div>
-    <div class="flex flex-wrap sm:-m-4 -mx-4 -mb-10 -mt-4">
-      <div class="p-4 md:w-1/3 sm:mb-0 mb-6">
-        <div class="rounded-lg h-64 overflow-hidden">
-          <img alt="content" class="object-cover object-center h-full w-full" src="https://dummyimage.com/1203x503">
-        </div>
-        <h2 class="text-xl font-medium title-font text-gray-900 mt-5">Shooting Stars</h2>
-        <p class="text-base leading-relaxed mt-2">Swag shoivdigoitch literally meditation subway tile tumblr cold-pressed. Gastropub street art beard dreamcatcher neutra, ethical XOXO lumbersexual.</p>
-        <span class="inline-flex">
-          <a class="text-gray-500">
-            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-5 h-5" viewBox="0 0 24 24">
-              <path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z"></path>
-            </svg>
-          </a>
-          <a class="ml-2 text-gray-500">
-            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-5 h-5" viewBox="0 0 24 24">
-              <path d="M23 3a10.9 10.9 0 01-3.14 1.53 4.48 4.48 0 00-7.86 3v1A10.66 10.66 0 013 4s-4 9 5 13a11.64 11.64 0 01-7 2c9 5 20 0 20-11.5a4.5 4.5 0 00-.08-.83A7.72 7.72 0 0023 3z"></path>
-            </svg>
-          </a>
-          <a class="ml-2 text-gray-500">
-            <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-5 h-5" viewBox="0 0 24 24">
-              <path d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z"></path>
-            </svg>
-          </a>
-        </span>
-        <a class="text-pink-500 inline-flex items-center mt-3">Learn More
-          <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
-            <path d="M5 12h14M12 5l7 7-7 7"></path>
-          </svg>
-        </a>
-      </div>
-      <div class="p-4 md:w-1/3 sm:mb-0 mb-6">
-        <div class="rounded-lg h-64 overflow-hidden">
-          <img alt="content" class="object-cover object-center h-full w-full" src="https://dummyimage.com/1204x504">
-        </div>
-        <h2 class="text-xl font-medium title-font text-gray-900 mt-5">The Catalyzer</h2>
-        <p class="text-base leading-relaxed mt-2">Swag shoivdigoitch literally meditation subway tile tumblr cold-pressed. Gastropub street art beard dreamcatcher neutra, ethical XOXO lumbersexual.</p>
-        <a class="text-pink-500 inline-flex items-center mt-3">Learn More
-          <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
-            <path d="M5 12h14M12 5l7 7-7 7"></path>
-          </svg>
-        </a>
-      </div>
-      <div class="p-4 md:w-1/3 sm:mb-0 mb-6">
-        <div class="rounded-lg h-64 overflow-hidden">
-          <img alt="content" class="object-cover object-center h-full w-full" src="https://dummyimage.com/1205x505">
-        </div>
-        <h2 class="text-xl font-medium title-font text-gray-900 mt-5">The 400 Blows</h2>
-        <p class="text-base leading-relaxed mt-2">Swag shoivdigoitch literally meditation subway tile tumblr cold-pressed. Gastropub street art beard dreamcatcher neutra, ethical XOXO lumbersexual.</p>
-        <a class="text-pink-500 inline-flex items-center mt-3">Learn More
-          <svg fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" class="w-4 h-4 ml-2" viewBox="0 0 24 24">
-            <path d="M5 12h14M12 5l7 7-7 7"></path>
-          </svg>
-        </a>
-      </div>
-    </div>
+    <% end %>
   </div>
-</section>
+</div>


### PR DESCRIPTION
## 概要
- 前回のコミットで実装した色塗り地図をパーシャルに切り分け
- その他全体のレイアウト調整

## 内容
- 不要な項目のコメントアウト
- 自身の投稿一覧追加
- マイページボタンリンク追加
- 投稿・編集ページのレイアウト調整