### PR TITLE
 bug: ブックマーク一覧でcontent missingとなるエラーを改善（ブックマーク2回で解除は後日対応）

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -66,9 +66,9 @@ class PostsController < ApplicationController
 
   def bookmarks
     # ブックマーク一覧を取得
-    @bookmark_posts = current_user.bookmark_posts.includes(:user, :prefecture, :tags)
+    @bookmark_posts = current_user.bookmark_posts.includes(:user, :prefecture, :tags).order(created_at: :desc)
     # タグに基づいて絞り込み
-    @bookmark_posts = @bookmark_posts.with_tag(params[:tag_name]) if params[:tag_name].present?
+    @bookmark_posts = @bookmark_posts.with_tag(params[:tag_name]).order(created_at: :desc) if params[:tag_name].present?
     @context = 'bookmarks'
   end
 

--- a/app/views/posts/_bookmark.html.erb
+++ b/app/views/posts/_bookmark.html.erb
@@ -1,4 +1,3 @@
-<%= link_to bookmarks_path(post_id: post.id), id: "bookmark-button-for-post-#{post.id}", data: { turbo_method: :post } do %>
+<%= link_to bookmarks_path(post_id: post.id), id: "bookmark-button-for-post-#{post.id}", data: { turbo_method: :post, turbo_frame: "_top" } do %>
   <i class="fa-regular fa-star"></i>
 <% end %>
-

--- a/app/views/posts/_unbookmark.html.erb
+++ b/app/views/posts/_unbookmark.html.erb
@@ -1,3 +1,3 @@
-<%= link_to bookmark_path(current_user.bookmarks.find_by(post_id: post.id)), id: "unbookmark-button-for-post-#{post.id}", data: { turbo_method: :delete } do %>
+<%= link_to bookmark_path(current_user.bookmarks.find_by(post_id: post.id)), id: "unbookmark-button-for-post-#{post.id}", data: { turbo_method: :delete, turbo_frame: "_top" } do %>
   <i class="fa-regular fa-face-laugh-squint"></i>
 <% end %>


### PR DESCRIPTION
- ブックマーク一覧でエラー解除時にconten missingとなる不具合を解消
- ブックマーク解除時にブックマークボタンが切り替わらないことが起因している様子。そちらは後日対応予定