### PR TITLE
 fix: メール送信時のエラー修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
 
   # 本番環境で実際にメールを送信する設定
   config.action_mailer.raise_delivery_errors = true
-
+  config.action_mailer.default_url_options = { host: 'saba-travel-app-71a92d1a59ff.herokuapp.com', protocol: 'https' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address:              'smtp.gmail.com',


### PR DESCRIPTION
## 概要
- ホスト情報不足によるエラーの修正

## 内容
- `config.action_mailer.default_url_options = { host: 'saba-travel-app-71a92d1a59ff.herokuapp.com', protocol: 'https' }`追記