### PR TITLE
 :art: style: リリースノートレイアウト崩れ修正

### DIFF
--- a/app/views/release_notes/_note.html.erb
+++ b/app/views/release_notes/_note.html.erb
@@ -1,5 +1,5 @@
 <div class="mt-4 flex items-center lg:w-3/5 mx-auto pb-10 mb-10 border-gray-200 sm:flex-row flex-col">
-  <div class="flex-grow text-left md:text-center mt-6 sm:mt-0">
+  <div class="flex-grow text-left md:mt-6 sm:mt-0">
     <% release_notes.each do |release_note| %>
       <div class="release-note border-b pb-10 mb-10 border-gray-200 sm:flex-row flex-col">
         <h2 class="text-gray-900 text-lg title-font font-medium mb-2"><%= release_note.title %></h2>


### PR DESCRIPTION
## 概要
- リリースノートが中央揃えになっていた部分を左寄せに修正

## 内容
- md:text-centerの記述を削除、同じ画面幅でローカル環境ではsm扱いになっていたが本番環境ではmd扱いになっていた