### PR TITLE
 :adhesive_bandage: fix: 全角読点でタグを分割した時に区切り文字として認識されるように設定

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -135,7 +135,7 @@ class PostsController < ApplicationController
 
   # タグの名前を取得し、分割して処理
   def extracted_tag_names
-    params[:post][:tag_names].to_s.split(/,\s*|\s+|\u3000+/).map(&:strip)
+    params[:post][:tag_names].to_s.split(/,\s*|\s+|\u3000+|、/).map(&:strip)
   end
 
   def load_posts


### PR DESCRIPTION
## 概要
- タグのsplitを拡張

## 内容
- 「、」も区切り文字として扱うように修正