### PR TITLE
Refactoring

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,9 +2,11 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[show edit update destroy]
   skip_before_action :require_login, only: %i[index show]
 
+  DEFAULT_TEXT = 'みんな'.freeze
+
   # /search
   def index
-    @text = 'みんな'
+    @text = DEFAULT_TEXT
     @q = Post.ransack(params[:q])
     @posts = load_posts
     @context = 'posts'
@@ -16,14 +18,6 @@ class PostsController < ApplicationController
     @user_prefectures = posts_count_by_prefecture.map do |prefecture_id, count|
       OpenStruct.new(prefecture_id:, post_count: count)
     end
-
-    # @posts = if (tag_name = params[:tag_name])
-    #            # タグ名に基づいて投稿を取得し、関連するユーザー、都道府県、タグを事前読み込み
-    #            Post.with_tag(tag_name).includes(:user, :prefecture, :tags).order(created_at: :desc)
-    #          else
-    #            # すべての投稿を取得し、関連するユーザー、都道府県、タグを事前読み込み
-    #            Post.includes(:user, :prefecture, :tags).order(created_at: :desc)
-    #          end
   end
 
   def new
@@ -100,7 +94,7 @@ class PostsController < ApplicationController
       @user_prefectures = post_counts.map do |prefecture_id, count|
         OpenStruct.new(prefecture_id:, post_count: count)
       end
-      @text = 'みんな'
+      @text = DEFAULT_TEXT
     end
 
     render partial: 'users/japanmap', locals: { user_prefectures: @user_prefectures, text: @text }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,7 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[show edit update destroy]
   skip_before_action :require_login, only: %i[index show]
 
-  DEFAULT_TEXT = 'みんな'.freeze
+  DEFAULT_TEXT = I18n.t('posts.default_text').freeze
 
   # /search
   def index
@@ -39,22 +39,16 @@ class PostsController < ApplicationController
   end
 
   def show
-    @post = Post.find(params[:id])
+    return unless @post.closed? && (!current_user || @post.user_id != current_user.id)
 
-    return unless @post.closed? && (current_user.nil? || @post.user_id != current_user.id)
-
-    flash[:alert] = 'その記事は存在しません'
-    redirect_to search_path
+    flash[:alert] = t('posts.not_found')
+    redirect_to search_path and return
   end
 
   # GET /posts/1/edit
-  def edit
-    @post = current_user.posts.find(params[:id])
-  end
+  def edit; end
 
   def update
-    @post = current_user.posts.find(params[:id])
-
     # TagAssigner サービスを使用してタグを割り当てる
     TagAssigner.new(@post, extracted_tag_names).assign_with_removal
 
@@ -68,8 +62,7 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    post = current_user.posts.find(params[:id])
-    post.destroy!
+    @post.destroy!
     flash[:notice] = t('defaults.flash.deleted', item: Post.model_name.human)
     redirect_to search_path, status: :see_other
   end
@@ -115,11 +108,21 @@ class PostsController < ApplicationController
     render partial: 'posts/autocompletes/tag_name', locals: { tag_names: @tag_names }
   end
 
+  def load_posts
+    @q = Post.ransack(params[:q])
+    @posts = @q.result # `distinct: true`を省略
+    @posts = @posts.with_tag(params[:tag_name]) if params[:tag_name].present?
+    @posts = @posts.exclude_unvisited_prefectures(current_user) if params[:exclude_unvisited_prefectures] == 'true'
+    @posts = @posts.by_status(current_user)
+    @posts = @posts.order(created_at: :desc)
+  end
+
   private
 
-  # Use callbacks to share common setup or constraints between actions.
   def set_post
     @post = Post.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to search_path, alert: t('posts.not_found')
   end
 
   # Only allow a list of trusted parameters through.
@@ -130,34 +133,5 @@ class PostsController < ApplicationController
   # タグの名前を取得し、分割して処理
   def extracted_tag_names
     params[:post][:tag_names].to_s.split(/,\s*|\s+|\u3000+|、/).map(&:strip)
-  end
-
-  def load_posts
-    posts = filtered_posts_by_status
-    posts = filter_posts_by_tag(posts) if params[:tag_name].present?
-    posts = posts.order(created_at: :desc)
-    exclude_unvisited_prefectures(posts)
-  end
-
-  def filter_posts_by_tag(posts)
-    posts.with_tag(params[:tag_name])
-  end
-
-  def filtered_posts_by_status
-    if current_user
-      @q.result.includes(:user, :prefecture, :tags)
-        .where('posts.user_id = :user_id OR posts.public_status = :public_status',
-               user_id: current_user.id, public_status: Post.public_statuses[:open])
-    else
-      @q.result.includes(:user, :prefecture, :tags)
-        .where(public_status: Post.public_statuses[:open])
-    end
-  end
-
-  def exclude_unvisited_prefectures(posts)
-    return posts unless params[:exclude_unvisited_prefectures] == 'true' && current_user
-
-    visited_prefecture_ids = current_user.posts.select(:prefecture_id).distinct.pluck(:prefecture_id)
-    posts.where.not(prefecture_id: visited_prefecture_ids)
   end
 end

--- a/app/models/concerns/addressable.rb
+++ b/app/models/concerns/addressable.rb
@@ -1,0 +1,27 @@
+# app/models/concerns/addressable.rb
+module Addressable
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :set_area_id, if: ->(obj) { obj.will_save_change_to_address? }
+  end
+
+  def set_area_id
+    city_name = extract_city_from_address
+    area_mapping = AreaMapping.find_by(prefecture_id:, city: city_name)
+    self.area_id = area_mapping&.area_id
+  end
+
+  private
+
+  def extract_city_from_address
+    address_without_prefecture = address.sub(/\A.*?[都道府県]/, '')
+    address_without_county = address_without_prefecture.sub(/.*?郡/, '')
+    city_name = address_without_county.split(/市|区|町|村/).first.strip
+    city_name += '市' if address.include?("#{city_name}市")
+    city_name += '区' if address.include?("#{city_name}区")
+    city_name += '町' if address.include?("#{city_name}町")
+    city_name += '村' if address.include?("#{city_name}村")
+    city_name
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,8 @@
+require_dependency 'concerns/addressable'
+
 class Post < ApplicationRecord
+  include Addressable
+
   belongs_to :user
   belongs_to :prefecture, optional: true
   belongs_to :city, optional: true
@@ -103,28 +107,5 @@ class Post < ApplicationRecord
     formatted = formatted.sub(/^\w+\+\w+\s日本、\s*/, '')
     # '日本、' を削除
     self.address = formatted.sub(/^日本、\s*/, '')
-  end
-
-  def set_area_id
-    city_name = extract_city_from_address
-    area_mapping = AreaMapping.find_by(prefecture_id:, city: city_name)
-    self.area_id = area_mapping&.area_id
-  end
-
-  def extract_city_from_address
-    # 都道府県名を除外
-    address_without_prefecture = address.sub(/\A.*?[都道府県]/, '')
-
-    # 郡名を除外（存在する場合）
-    address_without_county = address_without_prefecture.sub(/.*?郡/, '')
-
-    # 市区町村名を抽出
-    city_name = address_without_county.split(/市|区|町|村/).first.strip
-    city_name += '市' if address.include?("#{city_name}市")
-    city_name += '区' if address.include?("#{city_name}区")
-    city_name += '町' if address.include?("#{city_name}町")
-    city_name += '村' if address.include?("#{city_name}村")
-
-    city_name
   end
 end

--- a/app/views/tops/index.html.erb
+++ b/app/views/tops/index.html.erb
@@ -1,71 +1,64 @@
-<!-- 現状 -->
-<!-- 左に持ってくる要素 -->
-<div class="mt-4 text-gray-600 body-font">
-  <div class="container mx-auto flex px-5 mt-6 mb-4 items-center justify-center flex-col">
-    <% svg_path = Rails.root.join('app', 'assets', 'images', 'top.svg') %>
-    <% svg_data = File.read(svg_path) %>
+<section class="text-gray-600 body-font overflow-hidden">
+  <div class="container mx-auto">
+    <!-- 分割ここで指定 -->
+    <div class="lg:w-4/5 mx-auto flex flex-wrap justify-between">
+      <!-- 左の画像セクション -->
+      <div class="lg:w-1/2 w-full lg:p-0 mt-6 lg:mt-0 mx-auto flex justify-center items-center">
+        <% svg_path = Rails.root.join('app', 'assets', 'images', 'top.svg') %>
+        <% svg_data = File.read(svg_path) %>
 
-    <%# SVG ファイル内の <svg id="japan"> タグを見つけてクラスとdata-controller属性を追加する %>
-    <% element_id = 'japan' %>
-    <% class_name = 'top-count-1 animate-slide-in-fwd-center' %>
-    <% data_controller = 'map' %>
+        <%# SVG ファイル内の <svg id="japan"> タグを見つけてクラスとdata-controller属性を追加する %>
+        <% element_id = 'japan' %>
+        <% class_name = 'top-count-1 animate-slide-in-fwd-center' %>
+        <% data_controller = 'map' %>
 
-    <%# SVG タグにクラスとdata-controller属性を追加する %>
-    <% svg_data.gsub!(/<svg id="#{element_id}"( class="[^"]*")?/, '<svg id="' + element_id + '" class="' + class_name + '" data-controller="' + data_controller + '"') %>
-
-    <%= raw(svg_data).html_safe %>
-
-
-
-<!-- 右に持ってくる要素 -->
-
-    <div class="text-gray-600 body-font">
-      <div class="container px-5 py-8 mx-auto">
-        <div class="text-center mb-1">
-          <h1 id="use" class="sm:text-3xl text-2xl font-medium title-font text-gray-900 mb-1">このアプリの使い方</h1>
-          <div class="w-16 h-1 rounded-full bg-red-300 inline-flex"></div>
-          </div>
-        </div>
+        <%# SVG タグにクラスとdata-controller属性を追加する %>
+        <% svg_data.gsub!(/<svg id="#{element_id}"( class="[^"]*")?/, '<svg id="' + element_id + '" class="' + class_name + '" data-controller="' + data_controller + '"') %>
+        <%= raw(svg_data).html_safe %>
       </div>
-    </div>
 
-    <div class="text-gray-600 body-font mb-4">
-      <div class="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center rounded-lg border">
-        <div class="lg:max-w-lg lg:w-full md:w-1/2 w-5/6 mb-10 md:mb-0">
-          <img class="object-cover object-center rounded" alt="hero" src="https://i.gyazo.com/939e6f847a1bbd4764913f654401fbcf.png">
-        </div>
-        <div class="lg:flex-grow md:w-1/2 lg:pl-24 md:pl-16 flex flex-col md:items-start md:text-left items-center text-center">
-          <h1 class="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900">旅の思い出を投稿して<br>都道府県を彩りを添える
-          </h1>
-          <p class="mt-4 mb-2 leading-relaxed">あなたの旅の思い出を教えてください。</p>
-            <br>
-          <p class="mb-8 leading-relaxed">思い出が1つ増えると、あなたの訪れた都道府県が彩られていきます。</p>
-          <div class="flex justify-center">
-            <%= link_to '使ってみる', new_post_path, class: "ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg" %>
-          </div>
-          <div class="flex justify-center">
-            <div class="badge badge-outline mt-4">※ログイン限定機能です</div>
-          </div>
-        </div>
-      </div>
-    </div>
+      <!-- 右半分のセクションここから -->
+      <div class="lg:w-1/2 w-full lg:pl-10 lg:py-6 mt-6 lg:mt-0 relative">
+          <div class="flex flex-col mb-4 px-4">
+            <div class="text-gray-600 body-font mb-4">
+              <div class="container mx-auto flex px-5 py-10 md:flex-row flex-col items-center rounded-lg border">
+                <div class="lg:flex-grow md:w-1/2 flex flex-col items-center text-center">
+                  <div class="md:items-start md:text-left">
+                  <h1 class="title-font sm:text-xl text-xl mb-4 font-medium text-gray-900">旅の思い出を投稿して<br>都道府県を彩りを添える
+                  </h1>
+                  <p class="text-xs mt-4 mb-2 leading-relaxed">あなたの旅の思い出を教えてください。</p>
+                    <br>
+                  <p class="text-xs mb-8 leading-relaxed">思い出が1つ増えると、あなたの訪れた都道府県が彩られていきます。</p>
+                  </div>
+                  <!-- <img class="object-cover object-center rounded" alt="hero" src="https://i.gyazo.com/939e6f847a1bbd4764913f654401fbcf.png"> -->
+                  <div class="flex justify-center">
+                    <%= link_to '使ってみる', new_post_path, class: "text-xs ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg" %>
+                    <div class="ml-4 text-xs badge badge-outline mt-4">※ログイン限定機能です</div>
+                  </div>
+                </div>
+              </div>
+            </div>
 
-    <div class="text-gray-600 body-font mb-4">
-      <div class="container mx-auto flex px-5 py-24 md:flex-row flex-col items-center rounded-lg border">
-        <div class="lg:max-w-lg lg:w-full md:w-1/2 w-5/6 mb-10 md:mb-0">
-          <img class="object-cover object-center rounded" alt="hero" src="https://i.gyazo.com/778d72cb5ed7baa0b579b1015a00d035.png">
-        </div>
-        <div class="lg:flex-grow md:w-1/2 lg:pl-24 md:pl-16 flex flex-col md:items-start md:text-left items-center text-center">
-          <h1 class="title-font sm:text-4xl text-3xl mb-4 font-medium text-gray-900">みなさんの投稿から<br>彩ったことのない地を探す
-          </h1>
-          <p class="mt-4 mb-2 leading-relaxed">みなさんの思い出・彩りから、あなたがまだ訪れていない地を探してみませんか？</p>
-            <br>
-          <p class="mb-8 leading-relaxed">まだ見ぬ世界を発見し、あなたの思い出に彩りを加えてみてください。</p>
-          <div class="flex justify-center">
-            <%= link_to '使ってみる', search_path, class: "ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg" %>
+            <div class="text-gray-600 body-font mb-4">
+              <div class="container mx-auto flex px-5 py-10 md:flex-row flex-col items-center rounded-lg border">
+                <div class="lg:flex-grow md:w-1/2 flex flex-col items-center text-center">
+                  <div class="md:items-start md:text-left">
+                  <h1 class="title-font sm:text-xl text-xl mb-4 font-medium text-gray-900">みなさんの投稿から<br>彩ったことのない地を探す
+                  </h1>
+                  <p class="text-xs mt-4 mb-2 leading-relaxed">みなさんの思い出・彩りから、<br>あなたがまだ訪れていない地を探してみませんか？</p>
+                    <br>
+                  <p class="text-xs mb-8 leading-relaxed">まだ見ぬ世界を発見し、あなたの思い出に彩りを加えてみてください。</p>
+                  </div>
+                  <!-- <img class="object-cover object-center rounded" alt="hero" src="https://i.gyazo.com/778d72cb5ed7baa0b579b1015a00d035.png"> -->
+                  <div class="flex justify-center">
+                    <%= link_to '使ってみる', search_path, class: "text-xs ml-4 inline-flex text-gray-700 bg-gray-100 border-0 py-2 px-6 focus:outline-none hover:bg-gray-200 rounded text-lg" %>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-</div>
+</section>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -39,3 +39,6 @@ ja:
     update:
       success: パスワード更新に成功しました
       failure: パスワード更新に失敗しました
+  posts:
+    not_found: その記事は存在しません
+    default_text: みんな


### PR DESCRIPTION
## 概要
- [ ] 1. posts_controllerのindex内の文字列を代入している部分は、一度定数に切り出してそれを代入する
- [ ] 2. posts_controller内の共通の処理はprivateメソッドに切り出しておく
- [ ] 3. postモデルの住所から市区町村を取得するロジックはconcernに切り出して、それをmodelで読み込むようにする
- [ ] 4. 検索ロジックをmodelに切り出し
- [ ] 5. TOPページレイアウト修正

## 内容
### 1について
- 'みんな'と直書きしていた部分はi18n、ja.ymlにdefault_textとして定義した上で、`DEFAULT_TEXT = I18n.t('posts.default_text').freeze`定数に埋め込んだ上で使用するように修正致しました。
- その他フラッシュメッセージ直書き部分についてposts_controller内はi18nに対応させました。

### 2について
- set_postをshow, edit, update, destroyに対応させました。

### 3について
- set_area_id、extract_city_from_addressをmodels/concernsディレクトリに切り出しました。

### 4について
- 検索ロジックをmodelにscopeとして切り出しました。

### 5について
- TOPページをPCで閲覧した際に1画面に収まるようにレイアウトを調整いたしました。

## 該当issue
#193 #194

## その他のissueについて
#161 #162 #189 #190 #191 #195 のissueは本リリース後のタスクとして適宜調整を行う予定です。