### PR TITLE
 :adhesive_bandage: fix: ページネーションのボタン表示数を調整

### DIFF
--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -3,7 +3,7 @@
 Kaminari.configure do |config|
   config.default_per_page = 20
   # config.max_per_page = nil
-  config.window = 1
+  config.window = 5
   config.outer_window = 1
   # config.left = 0
   # config.right = 0


### PR DESCRIPTION
## 概要
- ページネーションボタン数の調整

## 内容
- config修正、前後5ボタンずつ表示されるように変更